### PR TITLE
Added middleware endpoint

### DIFF
--- a/lib/lotus/routing/endpoint_resolver.rb
+++ b/lib/lotus/routing/endpoint_resolver.rb
@@ -183,11 +183,14 @@ module Lotus
       end
 
       def constantize(string)
-        begin
-          ClassEndpoint.new(Utils::Class.load!(string, @namespace))
-        rescue NameError
-          LazyEndpoint.new(string, @namespace)
+        klass = Utils::Class.load!(string, @namespace)
+        if klass.respond_to?(:call)
+          Endpoint.new(klass)
+        else
+          ClassEndpoint.new(klass)
         end
+      rescue NameError
+        LazyEndpoint.new(string, @namespace)
       end
 
       def classify(string)

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -1,6 +1,32 @@
 require 'rexml/document'
 require 'lotus/routing/parsing/parser'
 
+module Web
+  module Controllers
+    module Home
+      class Index
+        # mocking class call method for middleware
+        def self.call(env)
+          code, headers, body = self.new.call(env)
+          [code, headers.merge('X-Middleware' => 'CALLED'), body]
+        end
+
+        def call(params)
+          [200, {}, ['Hello from Web::Controllers::Home::Index']]
+        end
+      end
+    end # Home
+
+    module Dashboard
+      class Index
+        def call(params)
+          [200, {}, ['Hello from Web::Controllers::Dashboard::Index']]
+        end
+      end
+    end # Dashboard
+  end
+end # Web
+
 module Api
   class App
     def call(env)

--- a/test/integration/middleware_integration_test.rb
+++ b/test/integration/middleware_integration_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+describe 'Lotus middleware integration' do
+  before do
+    @routes = Lotus::Router.new(namespace: Web::Controllers) do
+      get '/',          to: 'home#index'
+      get '/dashboard', to: 'dashboard#index'
+    end
+
+    @app = Rack::MockRequest.new(@routes)
+  end
+
+  it 'action with middleware' do
+    response = @app.get('/')
+    response.body.must_equal 'Hello from Web::Controllers::Home::Index'
+    response.status.must_equal 200
+    response.headers.fetch('X-Middleware').must_equal 'CALLED'
+  end
+
+  it 'action without middleware' do
+    response = @app.get('/dashboard')
+    response.body.must_equal 'Hello from Web::Controllers::Dashboard::Index'
+    response.status.must_equal 200
+    response.headers['X-Middleware'].must_be_nil
+  end
+end

--- a/test/routing/endpoint_resolver_test.rb
+++ b/test/routing/endpoint_resolver_test.rb
@@ -62,6 +62,22 @@ describe Lotus::Routing::EndpointResolver do
     end
   end
 
+  describe 'endpoint' do
+    before do
+      @resolver = Lotus::Routing::EndpointResolver.new(namespace: Web::Controllers)
+    end
+
+    it 'if :to is an action without middleware' do
+      options = { to: 'dashboard#index' }
+      @resolver.resolve(options).class.must_equal Lotus::Routing::ClassEndpoint
+    end
+
+    it 'if :to is an action with middleware' do
+      options = { to: 'home#index' }
+      @resolver.resolve(options).class.must_equal Lotus::Routing::Endpoint
+    end
+  end
+
   describe 'custom endpoint' do
     before :all do
       class CustomEndpoint


### PR DESCRIPTION
lotus/controller#72 Create a middleware endpoint for an action with one or several middlewares.

This is necessary for creating new PR in lotus/controller, fixing the rack.rb class.

Example:

```ruby
require 'lotus/router'
require 'lotus/controller'

class MyMiddleware
  def initialize(app)
   @app = app
  end

  def call(env)
    code, headers, body = @app.call(env)
    [code, headers.merge('X-Middleware' => 'CALLED'), body]
  end
end

module Home
  class Index
    include Lotus::Action
    use MyMiddleware

    def call(params)
      self.body = 'foo'
    end
  end
end

app = Lotus::Router.new do
  get '/', to: 'home#index'
end

Rack::Server.start app: app, Port: 2300
```
I haven't added new tests, ClassEndpoint isn't tested, how is it possible to test this MiddlewareEndpoint?