### PR TITLE
Added force_ssl option

### DIFF
--- a/lib/lotus/routing/force_ssl.rb
+++ b/lib/lotus/routing/force_ssl.rb
@@ -1,0 +1,136 @@
+module Lotus
+  module Routing
+    # Force ssl
+    #
+    # Redirect response to the secure equivalent resource (https)
+    #
+    # @since x.x.x
+    # @api private
+    class ForceSsl
+      # Https scheme
+      #
+      # @since x.x.x
+      # @api private
+      SSL_SCHEME = 'https'.freeze
+
+      # Location header
+      #
+      # @since x.x.x
+      # @api private
+      LOCATION_HEADER = 'Location'.freeze
+
+      # Default http port
+      #
+      # @since x.x.x
+      # @api private
+      DEFAULT_HTTP_PORT = 80
+
+      # Default ssl port
+      #
+      # @since x.x.x
+      # @api private
+      DEFAULT_SSL_PORT = 443
+
+      # Moved Permanently http code
+      #
+      # @since x.x.x
+      # @api private
+      MOVED_PERMANENTLY_HTTP_CODE = 301
+
+      # Temporary Redirect http code
+      #
+      # @since x.x.x
+      # @api private
+      TEMPORARY_REDIRECT_HTTP_CODE = 307
+
+      # Initialize force ssl class.
+      #
+      # @param force_ssl [Boolean] activate redirection to ssl
+      # @param options [Hash] activate redirection to ssl
+      # @option options [String] :default_host
+      # @option options [Integer] :default_port
+      # @option options [String] :scheme
+      #
+      # @since x.x.x
+      # @api private
+      def initialize(force_ssl, options = {})
+        @force_ssl      = force_ssl
+        @default_host   = options[:host]
+        @default_port   = options[:port]
+        @default_scheme = options[:scheme]
+      end
+
+      # Set 301 status and Location header if force_ssl is activated.
+      #
+      # @param env [Hash] a Rack env instance
+      #
+      # @return [Array]
+      #
+      # @see Lotus::Routing::HttpRouter#call
+      #
+      # @since x.x.x
+      # @api private
+      def call(env)
+        rack_request = ::Rack::Request.new(env)
+        [redirect_code(rack_request), { LOCATION_HEADER => full_url(rack_request) }, '']
+      end
+
+      # Check if router has to force the response with ssl
+      #
+      # @return [Boolean]
+      #
+      # @since x.x.x
+      # @api private
+      def force?(env)
+        rack_request = ::Rack::Request.new(env)
+        @force_ssl && !rack_request.scheme.eql?(SSL_SCHEME)
+      end
+
+      private
+
+      # Return full url to redirect
+      #
+      # @param request [Rack::Request] a Rack request
+      #
+      # @return [String]
+      #
+      # @since x.x.x
+      # @api private
+      def full_url(request)
+        url = "https://#{@default_host}"
+        url.concat(":#{default_port}")
+        url.concat(request.fullpath)
+      end
+
+      # Return redirect code
+      #
+      # @param request [Rack::Request] a Rack request
+      #
+      # @return [Integer]
+      #
+      # @since x.x.x
+      # @api private
+      def redirect_code(request)
+        if %w(GET HEAD).include? request.request_method
+          MOVED_PERMANENTLY_HTTP_CODE
+        else
+          TEMPORARY_REDIRECT_HTTP_CODE
+        end
+      end
+
+      # Return correct default port for full url
+      #
+      # @return [Integer]
+      #
+      # @since x.x.x
+      # @api private
+      def default_port
+        if @default_port.eql? DEFAULT_HTTP_PORT
+          DEFAULT_SSL_PORT
+        else
+          @default_port
+        end
+      end
+    end
+  end
+end

--- a/test/force_ssl_test.rb
+++ b/test/force_ssl_test.rb
@@ -1,0 +1,108 @@
+require 'test_helper'
+
+describe Lotus::Router do
+  %w{get}.each do |verb|
+    it "force_ssl to true and scheme is http, return 307 and new location, verb: #{verb}" do
+      router = Lotus::Router.new(force_ssl: true)
+      router.public_send(verb, '/http_destination', to: ->(env) { [200, {}, ['http destination!']] })
+      app = Rack::MockRequest.new(router)
+
+      status, headers, body = app.public_send(verb, '/http_destination')
+
+      status.must_equal 301
+      headers['Location'].must_equal 'https://localhost:443/http_destination'
+      body.body.must_equal ''
+    end
+
+    it "force_ssl to true and scheme is https, return 200, verb: #{verb}" do
+      router = Lotus::Router.new(force_ssl: true, scheme: 'https', host: 'lotus.test')
+      router.public_send(verb, '/http_destination', to: ->(env) { [200, {}, ['http destination!']] })
+      app = Rack::MockRequest.new(router)
+
+      status, headers, body = app.public_send(verb, 'https://lotus.test/http_destination')
+
+      status.must_equal 200
+      headers['Location'].must_be_nil
+      body.body.must_equal 'http destination!'
+    end
+  end
+
+  %w{post put patch delete options}.each do |verb|
+    it "force_ssl to true and scheme is http, return 307 and new location, verb: #{verb}" do
+      router = Lotus::Router.new(force_ssl: true)
+      router.public_send(verb, '/http_destination', to: ->(env) { [200, {}, ['http destination!']] })
+      app = Rack::MockRequest.new(router)
+
+      status, headers, body = app.public_send(verb, '/http_destination')
+
+      status.must_equal 307
+      headers['Location'].must_equal 'https://localhost:443/http_destination'
+      body.body.must_equal ''
+    end
+
+    it "force_ssl to true and added query string, verb: #{verb}" do
+      router = Lotus::Router.new(force_ssl: true)
+      router.public_send(verb, '/http_destination', to: ->(env) { [200, {}, ['http destination!']] })
+
+      app = Rack::MockRequest.new(router)
+
+      status, headers, body = app.public_send(verb, '/http_destination?foo=bar')
+
+      status.must_equal 307
+      headers['Location'].must_equal 'https://localhost:443/http_destination?foo=bar'
+      body.body.must_equal ''
+    end
+
+    it "force_ssl to true and added port, verb: #{verb}" do
+      router = Lotus::Router.new(force_ssl: true, port: 4000)
+      router.public_send(verb, '/http_destination', to: ->(env) { [200, {}, ['http destination!']] })
+
+      app = Rack::MockRequest.new(router)
+
+      status, headers, body = app.public_send(verb, '/http_destination?foo=bar')
+
+      status.must_equal 307
+      headers['Location'].must_equal 'https://localhost:4000/http_destination?foo=bar'
+      body.body.must_equal ''
+    end
+
+    it "force_ssl to true, added host and port, verb: #{verb}" do
+      router = Lotus::Router.new(force_ssl: true, host: 'lotusrb.org', port: 4000)
+      router.public_send(verb, '/http_destination', to: ->(env) { [200, {}, ['http destination!']] })
+
+      app = Rack::MockRequest.new(router)
+
+      status, headers, body = app.public_send(verb, '/http_destination?foo=bar')
+
+      status.must_equal 307
+      headers['Location'].must_equal 'https://lotusrb.org:4000/http_destination?foo=bar'
+      body.body.must_equal ''
+    end
+
+    it "force_ssl to false and scheme is http, return 200 and doesn't return new location, verb: #{verb}" do
+      router = Lotus::Router.new(force_ssl: false)
+      router.public_send(verb, '/http_destination', to: ->(env) { [200, {}, ['http destination!']] })
+
+      app = Rack::MockRequest.new(router)
+
+      status, headers, body = app.public_send(verb, '/http_destination')
+
+      status.must_equal 200
+      headers['Location'].must_be_nil
+      body.body.must_equal 'http destination!'
+    end
+
+    it "force_ssl to false and scheme is https, return 200 and doesn't return new location, verb: #{verb}" do
+      router = Lotus::Router.new(force_ssl: false, scheme: 'https')
+      router.public_send(verb, '/http_destination', to: ->(env) { [200, {}, ['http destination!']] })
+
+      app = Rack::MockRequest.new(router)
+
+      status, headers, body = app.public_send(verb, '/http_destination')
+
+      status.must_equal 200
+      headers['Location'].must_be_nil
+      body.body.must_equal 'http destination!'
+    end
+  end
+end


### PR DESCRIPTION
Resolves #56 

Now you can force ssl in your router:
```ruby
# notice scheme is http
@router = Lotus::Router.new(force_ssl: true) do
  get '/', to: 'home#index', as: :root
end
```
if you call to your app's home then `@router` return 301 status and Location `https://localhost/`