### PR TITLE
Added prefix option to router.

### DIFF
--- a/lib/lotus/router.rb
+++ b/lib/lotus/router.rb
@@ -341,7 +341,7 @@ module Lotus
     #    # It will map to Flowers::Index.new, which is the
     #    # Lotus::Controller convention.
     def get(path, options = {}, &blk)
-      @router.prefixed_namespace.get(path, options, &blk)
+      @router.get(path, options, &blk)
     end
 
     # Defines a route that accepts a POST request for the given path.
@@ -360,7 +360,7 @@ module Lotus
     #
     # @since 0.1.0
     def post(path, options = {}, &blk)
-      @router.prefixed_namespace.post(path, options, &blk)
+      @router.post(path, options, &blk)
     end
 
     # Defines a route that accepts a PUT request for the given path.
@@ -379,7 +379,7 @@ module Lotus
     #
     # @since 0.1.0
     def put(path, options = {}, &blk)
-      @router.prefixed_namespace.put(path, options, &blk)
+      @router.put(path, options, &blk)
     end
 
     # Defines a route that accepts a PATCH request for the given path.
@@ -398,7 +398,7 @@ module Lotus
     #
     # @since 0.1.0
     def patch(path, options = {}, &blk)
-      @router.prefixed_namespace.patch(path, options, &blk)
+      @router.patch(path, options, &blk)
     end
 
     # Defines a route that accepts a DELETE request for the given path.
@@ -417,7 +417,7 @@ module Lotus
     #
     # @since 0.1.0
     def delete(path, options = {}, &blk)
-      @router.prefixed_namespace.delete(path, options, &blk)
+      @router.delete(path, options, &blk)
     end
 
     # Defines a route that accepts a TRACE request for the given path.
@@ -436,7 +436,7 @@ module Lotus
     #
     # @since 0.1.0
     def trace(path, options = {}, &blk)
-      @router.prefixed_namespace.trace(path, options, &blk)
+      @router.trace(path, options, &blk)
     end
 
     # Defines a route that accepts a OPTIONS request for the given path.
@@ -455,7 +455,7 @@ module Lotus
     #
     # @since 0.1.0
     def options(path, options = {}, &blk)
-      @router.prefixed_namespace.options(path, options, &blk)
+      @router.options(path, options, &blk)
     end
 
     # Defines an HTTP redirect

--- a/lib/lotus/router.rb
+++ b/lib/lotus/router.rb
@@ -341,7 +341,7 @@ module Lotus
     #    # It will map to Flowers::Index.new, which is the
     #    # Lotus::Controller convention.
     def get(path, options = {}, &blk)
-      @router.get(path, options, &blk)
+      @router.prefixed_namespace.get(path, options, &blk)
     end
 
     # Defines a route that accepts a POST request for the given path.
@@ -360,7 +360,7 @@ module Lotus
     #
     # @since 0.1.0
     def post(path, options = {}, &blk)
-      @router.post(path, options, &blk)
+      @router.prefixed_namespace.post(path, options, &blk)
     end
 
     # Defines a route that accepts a PUT request for the given path.
@@ -379,7 +379,7 @@ module Lotus
     #
     # @since 0.1.0
     def put(path, options = {}, &blk)
-      @router.put(path, options, &blk)
+      @router.prefixed_namespace.put(path, options, &blk)
     end
 
     # Defines a route that accepts a PATCH request for the given path.
@@ -398,7 +398,7 @@ module Lotus
     #
     # @since 0.1.0
     def patch(path, options = {}, &blk)
-      @router.patch(path, options, &blk)
+      @router.prefixed_namespace.patch(path, options, &blk)
     end
 
     # Defines a route that accepts a DELETE request for the given path.
@@ -417,7 +417,7 @@ module Lotus
     #
     # @since 0.1.0
     def delete(path, options = {}, &blk)
-      @router.delete(path, options, &blk)
+      @router.prefixed_namespace.delete(path, options, &blk)
     end
 
     # Defines a route that accepts a TRACE request for the given path.
@@ -436,7 +436,7 @@ module Lotus
     #
     # @since 0.1.0
     def trace(path, options = {}, &blk)
-      @router.trace(path, options, &blk)
+      @router.prefixed_namespace.trace(path, options, &blk)
     end
 
     # Defines a route that accepts a OPTIONS request for the given path.
@@ -455,7 +455,7 @@ module Lotus
     #
     # @since 0.1.0
     def options(path, options = {}, &blk)
-      @router.options(path, options, &blk)
+      @router.prefixed_namespace.options(path, options, &blk)
     end
 
     # Defines an HTTP redirect

--- a/lib/lotus/routing/http_router.rb
+++ b/lib/lotus/routing/http_router.rb
@@ -3,6 +3,7 @@ require 'lotus/utils/io'
 require 'lotus/routing/endpoint_resolver'
 require 'lotus/routing/route'
 require 'lotus/routing/parsers'
+require 'lotus/utils/path_prefix'
 
 Lotus::Utils::IO.silence_warnings do
   HttpRouter::Route::VALID_HTTP_VERBS = %w{GET POST PUT PATCH DELETE HEAD OPTIONS TRACE}
@@ -43,7 +44,7 @@ module Lotus
         @route_class    = options[:route]    || Routing::Route
         @resolver       = options[:resolver] || Routing::EndpointResolver.new(options)
         @parsers        = Routing::Parsers.new(options[:parsers])
-        @prefix         = Routing::Namespace.new(self, options[:prefix]) if options[:prefix]
+        @prefix         = Utils::PathPrefix.new(options[:prefix] || '')
       end
 
       # Separator between controller and action name.
@@ -86,6 +87,66 @@ module Lotus
         _rescue_url_recognition { super }
       end
 
+      # Support for GET HTTP verb
+      #
+      # @see Lotus::Router#options
+      #
+      # @since x.x.x
+      # @api private
+      def get(path, options = {}, &blk)
+        super(@prefix.join(path), options, &blk)
+      end
+
+      # Support for POST HTTP verb
+      #
+      # @see Lotus::Router#post
+      #
+      # @since x.x.x
+      # @api private
+      def post(path, options = {}, &blk)
+        super(@prefix.join(path), options, &blk)
+      end
+
+      # Support for PUT HTTP verb
+      #
+      # @see Lotus::Router#put
+      #
+      # @since x.x.x
+      # @api private
+      def put(path, options = {}, &blk)
+        super(@prefix.join(path), options, &blk)
+      end
+
+      # Support for PATCH HTTP verb
+      #
+      # @see Lotus::Router#patch
+      #
+      # @since x.x.x
+      # @api private
+      def patch(path, options = {}, &blk)
+        super(@prefix.join(path), options, &blk)
+      end
+
+      # Support for DELETE HTTP verb
+      #
+      # @see Lotus::Router#delete
+      #
+      # @since x.x.x
+      # @api private
+      def delete(path, options = {}, &blk)
+        super(@prefix.join(path), options, &blk)
+      end
+
+      # Support for TRACE HTTP verb
+      #
+      # @see Lotus::Router#trace
+      #
+      # @since x.x.x
+      # @api private
+      def trace(path, options = {}, &blk)
+        super(@prefix.join(path), options, &blk)
+      end
+
       # Support for OPTIONS HTTP verb
       #
       # @see Lotus::Router#options
@@ -93,7 +154,7 @@ module Lotus
       # @since 0.1.0
       # @api private
       def options(path, options = {}, &blk)
-        add_with_request_method(path, :options, options, &blk)
+        add_with_request_method(@prefix.join(path), :options, options, &blk)
       end
 
       # Allow to mount a Rack app
@@ -132,14 +193,6 @@ module Lotus
         else
           @default_app.call(env)
         end
-      end
-
-      # Returns a prefix namespace or the current router
-      #
-      # @since x.x.x
-      # @api private
-      def prefixed_namespace
-        @prefix || self
       end
 
       private

--- a/lib/lotus/routing/http_router.rb
+++ b/lib/lotus/routing/http_router.rb
@@ -43,6 +43,7 @@ module Lotus
         @route_class    = options[:route]    || Routing::Route
         @resolver       = options[:resolver] || Routing::EndpointResolver.new(options)
         @parsers        = Routing::Parsers.new(options[:parsers])
+        @prefix         = Routing::Namespace.new(self, options[:prefix]) if options[:prefix]
       end
 
       # Separator between controller and action name.
@@ -131,6 +132,14 @@ module Lotus
         else
           @default_app.call(env)
         end
+      end
+
+      # Returns a prefix namespace or the current router
+      #
+      # @since x.x.x
+      # @api private
+      def prefixed_namespace
+        @prefix || self
       end
 
       private

--- a/lib/lotus/routing/namespace.rb
+++ b/lib/lotus/routing/namespace.rb
@@ -18,7 +18,7 @@ module Lotus
         @router = router
         @name   = Utils::PathPrefix.new(name)
         __setobj__(@router)
-        instance_eval(&blk) if block_given?
+        instance_eval(&blk)
       end
 
       # @api private

--- a/lib/lotus/routing/namespace.rb
+++ b/lib/lotus/routing/namespace.rb
@@ -18,7 +18,7 @@ module Lotus
         @router = router
         @name   = Utils::PathPrefix.new(name)
         __setobj__(@router)
-        instance_eval(&blk)
+        instance_eval(&blk) if block_given?
       end
 
       # @api private
@@ -54,6 +54,12 @@ module Lotus
       # @api private
       # @since 0.1.0
       def trace(path, options = {}, &endpoint)
+        super(@name.join(path), options, &endpoint)
+      end
+
+      # @api private
+      # @since 0.1.0
+      def options(path, options = {}, &endpoint)
         super(@name.join(path), options, &endpoint)
       end
 

--- a/test/prefix_test.rb
+++ b/test/prefix_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+describe Lotus::Router do
+  describe 'with prefix option' do
+    it 'generates routes with prefix' do
+      router = Lotus::Router.new(prefix: '/admin') do
+        get     '/home', to: 'home#index', as: :get_home
+        post    '/home', to: 'home#index', as: :post_home
+        put     '/home', to: 'home#index', as: :put_home
+        patch   '/home', to: 'home#index', as: :patch_home
+        delete  '/home', to: 'home#index', as: :delete_home
+        trace   '/home', to: 'home#index', as: :trace_home
+        options '/home', to: 'home#index', as: :options_home
+
+
+        resources :users
+        resource :asteroid
+
+        namespace :dashboard do
+          get '/home', to: 'dashboard#index', as: :dashboard_home
+        end
+      end
+      router.path(:get_home).must_equal    '/admin/home'
+      router.path(:post_home).must_equal   '/admin/home'
+      router.path(:put_home).must_equal    '/admin/home'
+      router.path(:patch_home).must_equal  '/admin/home'
+      router.path(:delete_home).must_equal '/admin/home'
+      router.path(:trace_home).must_equal  '/admin/home'
+      router.path(:options_home).must_equal'/admin/home'
+
+      router.path(:users).must_equal            '/admin/users'
+      router.path(:new_user).must_equal         '/admin/users/new'
+      router.path(:users).must_equal            '/admin/users'
+      router.path(:user, id: 1).must_equal      '/admin/users/1'
+      router.path(:edit_user, id: 1).must_equal '/admin/users/1/edit'
+
+      router.path(:new_asteroid).must_equal  '/admin/asteroid/new'
+      router.path(:asteroid).must_equal      '/admin/asteroid'
+      router.path(:edit_asteroid).must_equal '/admin/asteroid/edit'
+
+      router.path(:dashboard_home).must_equal '/admin/dashboard/home'
+    end
+
+    it 'redirect works with prefix' do
+      router = Lotus::Router.new(prefix: '/admin')
+      endpoint = ->(env) { [200, {}, ['Redirect destination!']] }
+      router.redirect('/redirect', to: '/redirect_destination')
+
+      env = Rack::MockRequest.env_for('/admin/redirect')
+      status, headers, _ = router.call(env)
+
+      status.must_equal 301
+      headers['Location'].must_equal '/redirect_destination'
+    end
+  end
+end


### PR DESCRIPTION
# Problem
There is a problem in lotusrb gem generating correct routes when the apps are mounted inside lotus container:
```ruby
class AdminApp  < Lotus::Application
  configure do
    routes do
      get '/home', to 'home#index', as: :home
    end
  end
end
Lotus::Container.configure do
  mount AdminApp, at: '/admin'
  mount App, at: '/'
end
AdminApp::Routes.path(:home) # => '/home' <- WRONG
# should be
AdminApp::Routes.path(:home) # => '/admin/home' <- GOOD
```

# Solution
This PR add prefix option to router, later we can pass in lotusrb the `at:` option as `prefix` for the router.

```ruby
router = Lotus::Router.new(prefix: '/admin') do
  get '/home', to: 'home#index', as: ':home'
end

router.path(:home) # => '/admin/home'
```
