### PR TITLE
Add failing rbx test for EndpointResolver

### DIFF
--- a/test/routing/endpoint_resolver_test.rb
+++ b/test/routing/endpoint_resolver_test.rb
@@ -92,7 +92,7 @@ describe Lotus::Routing::EndpointResolver do
       end
     end
 
-    it 'reponds to :routes' do
+    it 'responds to :routes' do
       @resolver.resolve(to: NestedRoutesApp).respond_to?(:routes).must_equal true
     end
 

--- a/test/routing/endpoint_resolver_test.rb
+++ b/test/routing/endpoint_resolver_test.rb
@@ -78,6 +78,29 @@ describe Lotus::Routing::EndpointResolver do
     end
   end
 
+  describe 'endpoint with nested routes' do
+    before :all do
+      class NestedRoutesApp
+        def call(env)
+        end
+
+        def routes
+          Lotus::Router.new do
+            get '/home', to: 'home#index'
+          end
+        end
+      end
+    end
+
+    it 'reponds to :routes' do
+      @resolver.resolve(to: NestedRoutesApp).respond_to?(:routes).must_equal true
+    end
+
+    after do
+      Object.send(:remove_const, :AdminLotusApp)
+    end
+  end
+
   describe 'custom endpoint' do
     before :all do
       class CustomEndpoint

--- a/test/routing/endpoint_resolver_test.rb
+++ b/test/routing/endpoint_resolver_test.rb
@@ -97,7 +97,7 @@ describe Lotus::Routing::EndpointResolver do
     end
 
     after do
-      Object.send(:remove_const, :AdminLotusApp)
+      Object.send(:remove_const, :NestedRoutesApp)
     end
   end
 


### PR DESCRIPTION
Currently Rbx has problems with classes which extend `SimpleDelegator`.

See rbx issue https://github.com/rubinius/rubinius/issues/3451 for further details.

To get a better grasp what exactly was failing I added this test.