### PR TITLE
Added args inspect to router exception messages

### DIFF
--- a/lib/lotus/routing/http_router.rb
+++ b/lib/lotus/routing/http_router.rb
@@ -146,15 +146,16 @@ module Lotus
       end
 
       private
-      def add_with_request_method(path, method, opts = {}, &app)
-        super.generate(@resolver, opts, &app)
-      end
 
       def _rescue_url_recognition
         yield
       rescue ::HttpRouter::InvalidRouteException,
              ::HttpRouter::TooManyParametersException => e
-        raise Routing::InvalidRouteException.new(e.message)
+        raise Routing::InvalidRouteException.new("#{ e.message } - please check given arguments")
+      end
+
+      def add_with_request_method(path, method, opts = {}, &app)
+        super.generate(@resolver, opts, &app)
       end
 
       def _custom_path(uri_string)

--- a/test/named_routes_test.rb
+++ b/test/named_routes_test.rb
@@ -27,9 +27,11 @@ describe Lotus::Router do
     end
 
     it "raises error when variables aren't satisfied" do
-      -> {
+      exception = -> {
         @router.path(:variables)
       }.must_raise(Lotus::Routing::InvalidRouteException)
+
+      exception.message.must_equal 'No route (path) could be generated for :variables - please check given arguments'
     end
 
     it 'recognizes string with variables and constraints' do
@@ -37,9 +39,11 @@ describe Lotus::Router do
     end
 
     it "raises error when constraints aren't satisfied" do
-      -> {
+      exception = -> {
         @router.path(:constraints, id: 'x')
       }.must_raise(Lotus::Routing::InvalidRouteException)
+
+      exception.message.must_equal 'No route (path) could be generated for :constraints - please check given arguments'
     end
 
     it 'recognizes optional variables' do
@@ -58,15 +62,19 @@ describe Lotus::Router do
     end
 
     it 'raises error when insufficient params are passed' do
-      -> {
+      exception = -> {
         @router.path(nil)
       }.must_raise(Lotus::Routing::InvalidRouteException)
+
+      exception.message.must_equal 'No route (path) could be generated for nil - please check given arguments'
     end
 
     it 'raises error when too many params are passed' do
-      -> {
+      exception = -> {
         @router.path(:fixed, 'x')
       }.must_raise(Lotus::Routing::InvalidRouteException)
+
+      exception.message.must_equal 'HttpRouter::TooManyParametersException - please check given arguments'
     end
   end
 
@@ -80,9 +88,11 @@ describe Lotus::Router do
     end
 
     it "raises error when variables aren't satisfied" do
-      -> {
+      exception = -> {
         @router.url(:variables)
       }.must_raise(Lotus::Routing::InvalidRouteException)
+
+      exception.message.must_equal 'No route (url) could be generated for :variables - please check given arguments'
     end
 
     it 'recognizes string with variables and constraints' do
@@ -90,9 +100,11 @@ describe Lotus::Router do
     end
 
     it "raises error when constraints aren't satisfied" do
-      -> {
+      exception = -> {
         @router.url(:constraints, id: 'x')
       }.must_raise(Lotus::Routing::InvalidRouteException)
+
+      exception.message.must_equal 'No route (url) could be generated for :constraints - please check given arguments'
     end
 
     it 'recognizes optional variables' do
@@ -111,15 +123,19 @@ describe Lotus::Router do
     end
 
     it 'raises error when insufficient params are passed' do
-      -> {
+      exception = -> {
         @router.url(nil)
       }.must_raise(Lotus::Routing::InvalidRouteException)
+
+      exception.message.must_equal 'No route (url) could be generated for nil - please check given arguments'
     end
 
     it 'raises error when too many params are passed' do
-      -> {
+      exception = -> {
         @router.url(:fixed, 'x')
       }.must_raise(Lotus::Routing::InvalidRouteException)
+
+      exception.message.must_equal 'HttpRouter::TooManyParametersException - please check given arguments'
     end
   end
 end

--- a/test/namespace_test.rb
+++ b/test/namespace_test.rb
@@ -181,7 +181,8 @@ describe Lotus::Router do
           @app.request('PATCH',  '/electronics/keyboards/23').status.must_equal  405
           @app.request('DELETE', '/electronics/keyboards/23').status.must_equal  405
 
-          -> { @router.path(:new_electronics_keyboards) }.must_raise Lotus::Routing::InvalidRouteException
+          exception = -> { @router.path(:new_electronics_keyboards) }.must_raise Lotus::Routing::InvalidRouteException
+          exception.message.must_equal 'No route (path) could be generated for :new_electronics_keyboards - please check given arguments'
         end
       end
 
@@ -208,7 +209,8 @@ describe Lotus::Router do
           @app.request('PATCH',  '/electronics/keyboards/23').status.must_equal  405
           @app.request('DELETE', '/electronics/keyboards/23').status.must_equal  405
 
-          -> { @router.path(:new_electronics_keyboards) }.must_raise Lotus::Routing::InvalidRouteException
+          exception = -> { @router.path(:new_electronics_keyboards) }.must_raise Lotus::Routing::InvalidRouteException
+          exception.message.must_equal 'No route (path) could be generated for :new_electronics_keyboards - please check given arguments'
         end
       end
 
@@ -292,7 +294,8 @@ describe Lotus::Router do
           @app.request('POST',   '/settings/profile').status.must_equal     405
           @app.request('DELETE', '/settings/profile').status.must_equal     405
 
-          -> { @router.path(:new_settings_profile) }.must_raise Lotus::Routing::InvalidRouteException
+          exception = -> { @router.path(:new_settings_profile) }.must_raise Lotus::Routing::InvalidRouteException
+          exception.message.must_equal 'No route (path) could be generated for :new_settings_profile - please check given arguments'
         end
       end
 
@@ -320,7 +323,8 @@ describe Lotus::Router do
         it 'does not recognize other paths' do
           @app.request('GET', '/settings/profile/edit').status.must_equal 404
 
-          -> { @router.path(:edit_settings_profile) }.must_raise Lotus::Routing::InvalidRouteException
+          exception = -> { @router.path(:edit_settings_profile) }.must_raise Lotus::Routing::InvalidRouteException
+          exception.message.must_equal 'No route (path) could be generated for :edit_settings_profile - please check given arguments'
         end
       end
     end

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -64,7 +64,8 @@ describe Lotus::Router do
         @app.request('GET',    '/profile').status.must_equal     405
         @app.request('DELETE', '/profile').status.must_equal     405
 
-        -> { @router.path(:new_profile) }.must_raise Lotus::Routing::InvalidRouteException
+        exception = -> { @router.path(:new_profile) }.must_raise Lotus::Routing::InvalidRouteException
+        exception.message.must_equal 'No route (path) could be generated for :new_profile - please check given arguments'
       end
     end
 
@@ -87,7 +88,8 @@ describe Lotus::Router do
         @app.request('GET',    '/profile').status.must_equal     405
         @app.request('DELETE', '/profile').status.must_equal     405
 
-        -> { @router.path(:new_profile) }.must_raise Lotus::Routing::InvalidRouteException
+        exception = -> { @router.path(:new_profile) }.must_raise Lotus::Routing::InvalidRouteException
+        exception.message.must_equal 'No route (path) could be generated for :new_profile - please check given arguments'
       end
     end
 

--- a/test/resources_test.rb
+++ b/test/resources_test.rb
@@ -70,7 +70,8 @@ describe Lotus::Router do
         @app.request('PATCH',  '/keyboards/23').status.must_equal  405
         @app.request('DELETE', '/keyboards/23').status.must_equal  405
 
-        -> { @router.path(:new_keyboards) }.must_raise Lotus::Routing::InvalidRouteException
+        exception = -> { @router.path(:new_keyboards) }.must_raise Lotus::Routing::InvalidRouteException
+        exception.message.must_equal 'No route (path) could be generated for :new_keyboards - please check given arguments'
       end
     end
 
@@ -95,7 +96,8 @@ describe Lotus::Router do
         @app.request('PATCH',  '/keyboards/23').status.must_equal  405
         @app.request('DELETE', '/keyboards/23').status.must_equal  405
 
-        -> { @router.path(:new_keyboards) }.must_raise Lotus::Routing::InvalidRouteException
+        exception = -> { @router.path(:new_keyboards) }.must_raise Lotus::Routing::InvalidRouteException
+        exception.message.must_equal 'No route (path) could be generated for :new_keyboards - please check given arguments'
       end
     end
 


### PR DESCRIPTION
Improved lotus router messages.

`No route (path) could be generated for :child - please check given arguments`