### PR TITLE
Parse JSON Body parameters for requests made with JSON API Content-Type

### DIFF
--- a/lib/lotus/routing/parsing/json_parser.rb
+++ b/lib/lotus/routing/parsing/json_parser.rb
@@ -5,7 +5,7 @@ module Lotus
     module Parsing
       class JsonParser < Parser
         def mime_types
-          ['application/json']
+          ['application/json', 'application/vnd.api+json']
         end
 
         def parse(body)

--- a/test/routing/parsers_test.rb
+++ b/test/routing/parsers_test.rb
@@ -50,6 +50,16 @@ describe Lotus::Routing::Parsers do
         end
       end
 
+      describe 'and a JSON API request' do
+        let(:body)         { %({"attribute":"ok"}) }
+        let(:content_type) { 'application/vnd.api+json' }
+
+        it "parses params from body" do
+          result = @parsers.call(env)
+          result['router.params'].must_equal({"attribute" => "ok"})
+        end
+      end
+
       describe 'and a non-JSON request' do
         let(:body)         { %(<element>ok</element>) }
         let(:content_type) { 'application/xml' }


### PR DESCRIPTION
The [JSON API specification](http://jsonapi.org/format/#content-negotiation) requires all requests to use the `Content-Type` `application/vnd.api+json`. Since the parameters are sent as JSON in the body, Rack ignores them. Therefore the work has to be done by Lotus, this adds the content type to the `JsonParser` so it correctly parses the requests. Otherwise the mismatch of the content types lead to missing/ignored parameters.