### PR TITLE
Added prefix for mounted apps in script_name

### DIFF
--- a/lib/lotus/routing/http_router.rb
+++ b/lib/lotus/routing/http_router.rb
@@ -30,6 +30,12 @@ module Lotus
     # @since 0.1.0
     # @api private
     class HttpRouter < ::HttpRouter
+      # Script name - rack enviroment variable
+      #
+      # @since x.x.x
+      # @api private
+      SCRIPT_NAME = 'SCRIPT_NAME'.freeze
+
       # Initialize the router.
       #
       # @see Lotus::Router#initialize
@@ -143,6 +149,12 @@ module Lotus
         else
           @default_app.call(env)
         end
+      end
+
+      # @api private
+      def rewrite_path_info(env, request)
+        super
+        env[SCRIPT_NAME] = @prefix + env[SCRIPT_NAME]
       end
 
       private

--- a/lotus-router.gemspec
+++ b/lotus-router.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler',  '~> 1.5'
   spec.add_development_dependency 'minitest', '~> 5'
   spec.add_development_dependency 'rake',     '~> 10'
+  spec.add_development_dependency 'rack-test', '~> 0.6'
 end

--- a/test/request_url_test.rb
+++ b/test/request_url_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+require 'rack/test'
+
+describe 'SCRIPT_NAME' do
+  include Rack::Test::Methods
+
+  before do
+    @container = Lotus::Router.new do
+      mount Lotus::Router.new(prefix: '/admin') {
+        get '/foo', to: ->(env) { [200, {}, [env['SCRIPT_NAME']]] }
+      }, at: '/admin'
+    end
+  end
+
+  def app
+    @container
+  end
+
+  def response
+    last_response
+  end
+
+  def request
+    last_request
+  end
+
+  it 'is successfuly parsing a JSON body' do
+    script_name = '/admin/foo'
+    get script_name
+
+    request.env['SCRIPT_NAME'].must_equal script_name
+    response.body.must_equal script_name
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/lotus/lotus/issues/344

Routes from mounted apps set `SCRIPT_NAME` variable without mounted prefix.

This PR adds the prefix to this variable 