### PR TITLE
Make Lotus::Routing::ForceSsl respect Rack spec

### DIFF
--- a/lib/lotus/routing/force_ssl.rb
+++ b/lib/lotus/routing/force_ssl.rb
@@ -81,7 +81,7 @@ module Lotus
       # @api private
       IDEMPOTENT_METHODS = ['GET', 'HEAD'].freeze
 
-      EMPTY_BODY = ''.freeze
+      EMPTY_BODY = [].freeze
 
       # Initialize ForceSsl.
       #

--- a/test/force_ssl_test.rb
+++ b/test/force_ssl_test.rb
@@ -1,6 +1,14 @@
 require 'test_helper'
 
 describe Lotus::Router do
+  it 'respects the Rack spec' do
+    router = Lotus::Router.new(force_ssl: true)
+    router.public_send(:get, '/http_destination', to: ->(env) { [200, {}, ['http destination!']] })
+    app = Rack::MockRequest.new(router)
+
+    app.get('/http_destination', lint: true)
+  end
+
   %w{get}.each do |verb|
     it "force_ssl to true and scheme is http, return 307 and new location, verb: #{verb}" do
       router = Lotus::Router.new(force_ssl: true)


### PR DESCRIPTION
According to Rack spec the response body must respond to #each.

Using '' as response body instead of [] causes server error
on request, when running application via ```bundle exec rackup```.

The ```bundle exec lotus server``` works normally, and correctly
forces SSL by redirecting without any error.

**To reproduce:**
```
$ lotus new force_ssl_test
```

```ruby
# config/routes.rb
get '/', to: ->(env) { [200, {}, ['OK']] }

# apps/web/application.rb
force_ssl true
```

```
$ bundle exec rackup
[2015-11-04 17:54:21] INFO  WEBrick 1.3.1
[2015-11-04 17:54:21] INFO  ruby 2.2.3 (2015-08-18) [x86_64-darwin15]
[2015-11-04 17:54:21] INFO  WEBrick::HTTPServer#start: pid=70829 port=9292
::1 - - [04/Nov/2015:17:54:31 +0300] "GET / HTTP/1.1" 301 - 0.0048
[2015-11-04 17:54:31] ERROR NoMethodError: undefined method `each' for "":String
	/Users/vlazar/.rvm/gems/ruby-2.2.3@force_ssl_test/gems/rack-1.6.4/lib/rack/body_proxy.rb:31:in `each'
	/Users/vlazar/.rvm/gems/ruby-2.2.3@force_ssl_test/gems/rack-1.6.4/lib/rack/lint.rb:708:in `each'
	/Users/vlazar/.rvm/gems/ruby-2.2.3@force_ssl_test/gems/rack-1.6.4/lib/rack/body_proxy.rb:31:in `each'
	/Users/vlazar/.rvm/gems/ruby-2.2.3@force_ssl_test/gems/rack-1.6.4/lib/rack/chunked.rb:23:in `each'
	/Users/vlazar/.rvm/gems/ruby-2.2.3@force_ssl_test/gems/rack-1.6.4/lib/rack/handler/webrick.rb:112:in `service'
	/Users/vlazar/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
	/Users/vlazar/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
	/Users/vlazar/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
```

```
$ http http://localhost:9292/
HTTP/1.1 500 Internal Server Error
Connection: close
Content-Type: text/html; charset=ISO-8859-1
Date: Wed, 04 Nov 2015 14:04:16 GMT
Location: https://localhost:2300/
Server: WEBrick/1.3.1 (Ruby/2.2.3/2015-08-18)
Transfer-Encoding: chunked


http: error: ChunkedEncodingError: ('Connection broken: IncompleteRead(0 bytes read)', IncompleteRead(0 bytes read))
```

Fixes #73