### PR TITLE
Introduce Lotus::Router.define

### DIFF
--- a/lib/lotus/router.rb
+++ b/lib/lotus/router.rb
@@ -71,6 +71,39 @@ module Lotus
   #
   #   # All the requests starting with "/api" will be forwarded to Api::App
   class Router
+    # Returns the given block as it is.
+    #
+    # When Lotus::Router is used as a standalone gem and the routes are defined
+    # into a configuration file, some systems could raise an exception.
+    #
+    # Imagine the following file into a Ruby on Rails application:
+    #
+    #   get '/', to: 'api#index'
+    #
+    # Because Ruby on Rails in production mode use to eager load code and the
+    # routes file uses top level method calls, it crashes the application.
+    #
+    # If we wrap these routes with <tt>Lotus::Router.define</tt>, the block
+    # doesn't get yielded but just returned to the caller as it is.
+    #
+    # Usually the receiver of this block is <tt>Lotus::Router#initialize</tt>,
+    # which finally evaluates the block.
+    #
+    # @param blk [Proc] a set of route definitions
+    #
+    # @return [Proc] the given block
+    #
+    # @since x.x.x
+    #
+    # @example
+    #   # apps/web/config/routes.rb
+    #   Lotus::Router.define do
+    #     get '/', to: 'home#index'
+    #   end
+    def self.define(&blk)
+      blk
+    end
+
     # Initialize the router.
     #
     # @param options [Hash] the options to initialize the router

--- a/test/new_test.rb
+++ b/test/new_test.rb
@@ -25,6 +25,17 @@ describe Lotus::Router do
       router.must_be_instance_of Lotus::Router
     end
 
+    it 'evaluates routes passed from Lotus::Router.define' do
+      routes = Lotus::Router.define { post '/domains', to: ->(env) {[201, {}, ['Domain Created']]} }
+      router = Lotus::Router.new(&routes)
+
+      app      = Rack::MockRequest.new(router)
+      response = app.post('/domains', lint: true)
+
+      response.status.must_equal 201
+      response.body.must_equal   'Domain Created'
+    end
+
     it 'returns instance of Lotus::Router' do
       @router.must_be_instance_of Lotus::Router
     end

--- a/test/router_test.rb
+++ b/test/router_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+describe Lotus::Router do
+  describe '.define' do
+    it 'returns block as it is' do
+      routes = -> { get '/', to: ->(env) {[200, {}, ['OK']]} }
+      Lotus::Router.define(&routes).must_equal routes
+    end
+  end
+end


### PR DESCRIPTION
Returns the given block as it is.

When `Lotus::Router` is used as a standalone gem and the routes are defined into a configuration file, some systems could raise an exception.

Imagine the following file into a Ruby on Rails application:

```ruby
# app/api/config/routes.rb
get '/', to: 'api#index'
```

Because Ruby on Rails in production mode use to eager load code and the routes file uses top level method calls, it crashes the application.

If we wrap these routes with `Lotus::Router.define`, the block doesn't get yielded but just returned to the caller as it is.

Usually the receiver of this block is `Lotus::Router#initialize`, which finally evaluates the block.

/cc @lotus/core-team @weppos 