### PR TITLE
Introducing Lotus::Router#recognize as testing facility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ if !ENV['TRAVIS']
   gem 'yard',   require: false
 end
 
-gem 'lotus-utils', '~> 0.6', require: false, github: 'lotus/utils', branch: '0.6.x'
+gem 'lotus-utils', '~> 0.6', require: false, github: 'lotus/utils', branch: 'string-rsub'
 gem 'simplecov',             require: false
 gem 'coveralls',             require: false

--- a/README.md
+++ b/README.md
@@ -640,14 +640,26 @@ curl http://localhost:2300/authors/1 \
 
 ```ruby
 require 'lotus/router'
-require 'rack/request'
 
 router = Lotus::Router.new do
-  get '/', to: ->(env) { [200, {}, ['Hi!']] }
+  get '/books/:id', to: 'books#show', as: :book
 end
 
-app = Rack::MockRequest.new(router)
-app.get('/') # => #<Rack::MockResponse:0x007fc4540dc238 ...>
+route = router.recognize('/books/23')
+route.verb      # "GET"
+route.action    # => "books#show"
+route.params    # => {:id=>"23"}
+route.routable? # => true
+
+route = router.recognize(:book, id: 23)
+route.verb      # "GET"
+route.action    # => "books#show"
+route.params    # => {:id=>"23"}
+route.routable? # => true
+
+route = router.recognize('/books/23', method: :post)
+route.verb      # "POST"
+route.routable? # => false
 ```
 
 ## Versioning

--- a/lib/lotus/router.rb
+++ b/lib/lotus/router.rb
@@ -1,3 +1,4 @@
+require 'rack/request'
 require 'lotus/routing/http_router'
 require 'lotus/routing/namespace'
 require 'lotus/routing/resource'
@@ -71,6 +72,24 @@ module Lotus
   #
   #   # All the requests starting with "/api" will be forwarded to Api::App
   class Router
+    # This error is raised when <tt>#call</tt> is invoked on a non-routable
+    # recognized route.
+    #
+    # @since x.x.x
+    #
+    # @see Lotus::Router#recognize
+    # @see Lotus::Routing::RecognizedRoute
+    # @see Lotus::Routing::RecognizedRoute#call
+    # @see Lotus::Routing::RecognizedRoute#routable?
+    class NotRoutableEndpointError < ::StandardError
+      REQUEST_METHOD = 'REQUEST_METHOD'.freeze
+      PATH_INFO      = 'PATH_INFO'.freeze
+
+      def initialize(env)
+        super %(Cannot find routable endpoint for #{ env[REQUEST_METHOD] } "#{ env[PATH_INFO] }")
+      end
+    end
+
     # Returns the given block as it is.
     #
     # When Lotus::Router is used as a standalone gem and the routes are defined
@@ -911,6 +930,125 @@ module Lotus
       @router.call(env)
     end
 
+    # Recognize the given env, path, or name and return a route for testing
+    # inspection.
+    #
+    # If the route cannot be recognized, it still returns an object for testing
+    # inspection.
+    #
+    # @param env [Hash, String, Symbol] Rack env, path or route name
+    # @param options [Hash] a set of options for Rack env or route params
+    # @param params [Hash] a set of params
+    #
+    # @return [Lotus::Routing::RecognizedRoute] the recognized route
+    #
+    # @since x.x.x
+    #
+    # @see Lotus::Router#env_for
+    # @see Lotus::Routing::RecognizedRoute
+    #
+    # @example Successful Path Recognition
+    #   require 'lotus/router'
+    #
+    #   router = Lotus::Router.new do
+    #     get '/books/:id', to: 'books#show', as: :book
+    #   end
+    #
+    #   route = router.recognize('/books/23')
+    #   route.verb      # => "GET" (default)
+    #   route.routable? # => true
+    #   route.params    # => {:id=>"23"}
+    #
+    # @example Successful Rack Env Recognition
+    #   require 'lotus/router'
+    #
+    #   router = Lotus::Router.new do
+    #     get '/books/:id', to: 'books#show', as: :book
+    #   end
+    #
+    #   route = router.recognize(Rack::MockRequest.env_for('/books/23'))
+    #   route.verb      # => "GET" (default)
+    #   route.routable? # => true
+    #   route.params    # => {:id=>"23"}
+    #
+    # @example Successful Named Route Recognition
+    #   require 'lotus/router'
+    #
+    #   router = Lotus::Router.new do
+    #     get '/books/:id', to: 'books#show', as: :book
+    #   end
+    #
+    #   route = router.recognize(:book, id: 23)
+    #   route.verb      # => "GET" (default)
+    #   route.routable? # => true
+    #   route.params    # => {:id=>"23"}
+    #
+    # @example Failing Recognition For Unknown Path
+    #   require 'lotus/router'
+    #
+    #   router = Lotus::Router.new do
+    #     get '/books/:id', to: 'books#show', as: :book
+    #   end
+    #
+    #   route = router.recognize('/books')
+    #   route.verb      # => "GET" (default)
+    #   route.routable? # => false
+    #
+    # @example Failing Recognition For Path With Wrong HTTP Verb
+    #   require 'lotus/router'
+    #
+    #   router = Lotus::Router.new do
+    #     get '/books/:id', to: 'books#show', as: :book
+    #   end
+    #
+    #   route = router.recognize('/books/23', method: :post)
+    #   route.verb      # => "POST"
+    #   route.routable? # => false
+    #
+    # @example Failing Recognition For Rack Env With Wrong HTTP Verb
+    #   require 'lotus/router'
+    #
+    #   router = Lotus::Router.new do
+    #     get '/books/:id', to: 'books#show', as: :book
+    #   end
+    #
+    #   route = router.recognize(Rack::MockRequest.env_for('/books/23', method: :post))
+    #   route.verb      # => "POST"
+    #   route.routable? # => false
+    #
+    # @example Failing Recognition Named Route With Wrong Params
+    #   require 'lotus/router'
+    #
+    #   router = Lotus::Router.new do
+    #     get '/books/:id', to: 'books#show', as: :book
+    #   end
+    #
+    #   route = router.recognize(:book)
+    #   route.verb      # => "GET" (default)
+    #   route.routable? # => false
+    #
+    # @example Failing Recognition Named Route With Wrong HTTP Verb
+    #   require 'lotus/router'
+    #
+    #   router = Lotus::Router.new do
+    #     get '/books/:id', to: 'books#show', as: :book
+    #   end
+    #
+    #   route = router.recognize(:book, {method: :post}, {id: 1})
+    #   route.verb      # => "POST"
+    #   route.routable? # => false
+    #   route.params    # => {:id=>"1"}
+    def recognize(env, options = {}, params = nil)
+      require 'lotus/routing/recognized_route'
+
+      env          = env_for(env, options, params)
+      responses, _ = *@router.recognize(env)
+
+      Routing::RecognizedRoute.new(
+        responses.nil? ? responses : responses.first,
+        env, @router)
+    end
+
     # Generate an relative URL for a specified named route.
     # The additional arguments will be used to compose the relative URL - in
     #   case it has tokens to match - and for compose the query string.
@@ -989,6 +1127,37 @@ module Lotus
     def inspector
       require 'lotus/routing/routes_inspector'
       Routing::RoutesInspector.new(@router.routes)
+    end
+
+    protected
+
+    # Fabricate Rack env for the given Rack env, path or named route
+    #
+    # @param env [Hash, String, Symbol] Rack env, path or route name
+    # @param options [Hash] a set of options for Rack env or route params
+    # @param params [Hash] a set of params
+    #
+    # @return [Hash] Rack env
+    #
+    # @since x.x.x
+    # @api private
+    #
+    # @see Lotus::Router#recognize
+    # @see http://www.rubydoc.info/github/rack/rack/Rack%2FMockRequest.env_for
+    def env_for(env, options = {}, params = nil)
+      env = case env
+      when String
+        Rack::MockRequest.env_for(env, options)
+      when Symbol
+        begin
+          url = path(env, params || options)
+          return env_for(url, options)
+        rescue Lotus::Routing::InvalidRouteException
+          {}
+        end
+      else
+        env
+      end
     end
   end
 end

--- a/lib/lotus/routing/http_router.rb
+++ b/lib/lotus/routing/http_router.rb
@@ -36,6 +36,10 @@ module Lotus
       # @api private
       SCRIPT_NAME = 'SCRIPT_NAME'.freeze
 
+      # @since x.x.x
+      # @api private
+      attr_reader :namespace
+
       # Initialize the router.
       #
       # @see Lotus::Router#initialize
@@ -45,9 +49,10 @@ module Lotus
       def initialize(options = {}, &blk)
         super(options, &nil)
 
-        @default_scheme   = options[:scheme]   if options[:scheme]
-        @default_host     = options[:host]     if options[:host]
-        @default_port     = options[:port]     if options[:port]
+        @namespace        = options[:namespace] if options[:namespace]
+        @default_scheme   = options[:scheme]    if options[:scheme]
+        @default_host     = options[:host]      if options[:host]
+        @default_port     = options[:port]      if options[:port]
         @route_class      = options[:route]    || Routing::Route
         @resolver         = options[:resolver] || Routing::EndpointResolver.new(options)
         @parsers          = Routing::Parsers.new(options[:parsers])

--- a/lib/lotus/routing/recognized_route.rb
+++ b/lib/lotus/routing/recognized_route.rb
@@ -1,0 +1,153 @@
+require 'lotus/utils/string'
+
+module Lotus
+  module Routing
+    # Represents a result of router path recognition.
+    #
+    # @since x.x.x
+    #
+    # @see Lotus::Router#recognize
+    class RecognizedRoute
+      # @since x.x.x
+      # @api private
+      REQUEST_METHOD = 'REQUEST_METHOD'.freeze
+
+      # @since x.x.x
+      # @api private
+      NAMESPACE             = '%s::'.freeze
+
+      # @since x.x.x
+      # @api private
+      NAMESPACE_REPLACEMENT = ''.freeze
+
+      # @since x.x.x
+      # @api private
+      ACTION_PATH_SEPARATOR = '/'.freeze
+
+      # @since x.x.x
+      # @api public
+      attr_reader :params
+
+      # Creates a new instance
+      #
+      # @param response [HttpRouter::Response] raw response of recognition
+      # @param env [Hash] Rack env
+      # @param router [Lotus::Routing::HttpRouter] low level router
+      #
+      # @return [Lotus::Routing::RecognizedRoute]
+      #
+      # @since x.x.x
+      # @api private
+      def initialize(response, env, router)
+        @env = env
+
+        unless response.nil?
+          @endpoint = response.route.dest
+          @params   = response.params
+        end
+
+        @namespace        = router.namespace
+        @action_separator = router.action_separator
+      end
+
+      # Rack protocol compatibility
+      #
+      # @param env [Hash] Rack env
+      #
+      # @return [Array] serialized Rack response
+      #
+      # @raise [Lotus::Router::NotRoutableEndpointError] if not routable
+      #
+      # @since x.x.x
+      # @api public
+      #
+      # @see Lotus::Routing::RecognizedRoute#routable?
+      # @see Lotus::Router::NotRoutableEndpointError
+      def call(env)
+        if routable?
+          @endpoint.call(env)
+        else
+          raise Lotus::Router::NotRoutableEndpointError.new(@env)
+        end
+      end
+
+      # HTTP verb (aka method)
+      #
+      # @return [String]
+      #
+      # @since x.x.x
+      # @api public
+      def verb
+        @env[REQUEST_METHOD]
+      end
+
+      # Action name
+      #
+      # @return [String]
+      #
+      # @since x.x.x
+      # @api public
+      #
+      # @see Lotus::Router#recognize
+      #
+      # @example
+      #   require 'lotus/router'
+      #
+      #   router = Lotus::Router.new do
+      #     get '/books/:id', to: 'books#show'
+      #   end
+      #
+      #   puts router.recognize('/books/23').action # => "books#show"
+      def action
+        namespace = NAMESPACE % @namespace
+
+        if destination.match(namespace)
+          Lotus::Utils::String.new(
+            destination.sub(namespace, NAMESPACE_REPLACEMENT)
+          ).underscore.rsub(ACTION_PATH_SEPARATOR, @action_separator)
+        else
+          destination
+        end
+      end
+
+      # Check if routable
+      #
+      # @return [TrueClass,FalseClass]
+      #
+      # @since x.x.x
+      # @api public
+      #
+      # @see Lotus::Router#recognize
+      #
+      # @example
+      #   require 'lotus/router'
+      #
+      #   router = Lotus::Router.new do
+      #     get '/', to: 'home#index'
+      #   end
+      #
+      #   puts router.recognize('/').routable?    # => true
+      #   puts router.recognize('/foo').routable? # => false
+      def routable?
+        !!@endpoint
+      end
+
+      private
+
+      # @since x.x.x
+      # @api private
+      #
+      # @see Lotus::Routing::Endpoint
+      def destination
+        @destination ||= begin
+          case k = @endpoint.__getobj__
+          when Class
+            k
+          else
+            k.class
+          end.name
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -391,11 +391,13 @@ end
 
 class RackMiddleware
   def self.call(env)
+    [200, {}, ['RackMiddleware']]
   end
 end
 
 class RackMiddlewareInstanceMethod
   def call(env)
+    [200, {}, ['RackMiddlewareInstanceMethod']]
   end
 end
 

--- a/test/recognize_test.rb
+++ b/test/recognize_test.rb
@@ -1,0 +1,272 @@
+require 'test_helper'
+
+describe Lotus::Router do
+  describe '#recognize' do
+    before do
+      @router = Lotus::Router.new(namespace: Web::Controllers) do
+        get '/',              to: 'home#index',                       as: :home
+        get '/dashboard',     to: Web::Controllers::Dashboard::Index, as: :dashboard
+        get '/rack_class',    to: RackMiddleware,                     as: :rack_class
+        get '/rack_app',      to: RackMiddlewareInstanceMethod,       as: :rack_app
+        get '/proc',          to: ->(env) { [200, {}, ['OK']] },      as: :proc
+        get '/resources/:id', to: ->(env) { [200, {}, ['PARAMS']] },  as: :params
+      end
+    end
+
+    describe 'from Rack env' do
+      it 'recognizes proc' do
+        env   = Rack::MockRequest.env_for('/proc', method: :get)
+        route = @router.recognize(env)
+
+        _, _, body = *route.call({})
+
+        body.must_equal      ['OK']
+        route.verb.must_equal 'GET'
+
+        assert route.routable?, "Expected route to be routable"
+      end
+
+      it 'recognizes procs with params' do
+        env   = Rack::MockRequest.env_for('/resources/1', method: :get)
+        route = @router.recognize(env)
+
+        route.params.must_equal(id: "1")
+      end
+
+      it 'recognizes action with naming convention (home#index)' do
+        env   = Rack::MockRequest.env_for('/', method: :get)
+        route = @router.recognize(env)
+
+        _, _, body = *route.call({})
+
+        body.must_equal      ["Hello from Web::Controllers::Home::Index"]
+        route.verb.must_equal 'GET'
+
+        route.action.must_equal('home#index')
+        assert route.routable?, "Expected route to be routable"
+      end
+
+      it 'recognizes action from class' do
+        env   = Rack::MockRequest.env_for('/dashboard', method: :get)
+        route = @router.recognize(env)
+
+        _, _, body = *route.call({})
+
+        body.must_equal      ["Hello from Web::Controllers::Dashboard::Index"]
+        route.verb.must_equal 'GET'
+
+        route.action.must_equal('dashboard#index')
+        assert route.routable?, "Expected route to be routable"
+      end
+
+      it 'recognizes action from rack middleware class' do
+        env   = Rack::MockRequest.env_for('/rack_class', method: :get)
+        route = @router.recognize(env)
+
+        _, _, body = *route.call({})
+
+        body.must_equal      ["RackMiddleware"]
+        route.verb.must_equal 'GET'
+
+        route.action.must_equal('RackMiddleware')
+        assert route.routable?, "Expected route to be routable"
+      end
+
+      it 'recognizes action from rack middleware' do
+        env   = Rack::MockRequest.env_for('/rack_app', method: :get)
+        route = @router.recognize(env)
+
+        _, _, body = *route.call({})
+
+        body.must_equal      ["RackMiddlewareInstanceMethod"]
+        route.verb.must_equal 'GET'
+
+        route.action.must_equal('RackMiddlewareInstanceMethod')
+        assert route.routable?, "Expected route to be routable"
+      end
+
+      it 'returns not routeable result when cannot recognize' do
+        env   = Rack::MockRequest.env_for('/', method: :post)
+        route = @router.recognize(env)
+
+        assert !route.routable?, "Expected route to NOT be routable"
+      end
+
+      it 'raises error if #call is invoked for not routeable object when cannot recognize' do
+        env   = Rack::MockRequest.env_for('/', method: :post)
+        route = @router.recognize(env)
+
+        exception = -> { route.call(env) }.must_raise Lotus::Router::NotRoutableEndpointError
+        exception.message.must_equal 'Cannot find routable endpoint for POST "/"'
+      end
+    end
+
+    describe 'from path' do
+      it 'recognizes proc' do
+        route = @router.recognize('/proc')
+
+        _, _, body = *route.call({})
+
+        body.must_equal      ['OK']
+        route.verb.must_equal 'GET'
+
+        assert route.routable?, "Expected route to be routable"
+      end
+
+      it 'recognizes procs with params' do
+        route = @router.recognize('/resources/1')
+
+        route.params.must_equal(id: "1")
+      end
+
+      it 'recognizes action with naming convention (home#index)' do
+        route = @router.recognize('/')
+
+        _, _, body = *route.call({})
+
+        body.must_equal      ["Hello from Web::Controllers::Home::Index"]
+        route.verb.must_equal 'GET'
+
+        route.action.must_equal('home#index')
+        assert route.routable?, "Expected route to be routable"
+      end
+
+      it 'recognizes action from class' do
+        route = @router.recognize('/dashboard')
+
+        _, _, body = *route.call({})
+
+        body.must_equal      ["Hello from Web::Controllers::Dashboard::Index"]
+        route.verb.must_equal 'GET'
+
+        route.action.must_equal('dashboard#index')
+        assert route.routable?, "Expected route to be routable"
+      end
+
+      it 'recognizes action from rack middleware class' do
+        route = @router.recognize('/rack_class')
+
+        _, _, body = *route.call({})
+
+        body.must_equal      ["RackMiddleware"]
+        route.verb.must_equal 'GET'
+
+        route.action.must_equal('RackMiddleware')
+        assert route.routable?, "Expected route to be routable"
+      end
+
+      it 'recognizes action from rack middleware' do
+        route = @router.recognize('/rack_app')
+
+        _, _, body = *route.call({})
+
+        body.must_equal      ["RackMiddlewareInstanceMethod"]
+        route.verb.must_equal 'GET'
+
+        route.action.must_equal('RackMiddlewareInstanceMethod')
+        assert route.routable?, "Expected route to be routable"
+      end
+
+      it 'returns not routeable result when cannot recognize' do
+        route = @router.recognize('/', method: :post)
+
+        assert !route.routable?, "Expected route to NOT be routable"
+      end
+
+      it 'raises error if #call is invoked for not routeable object when cannot recognize' do
+        env   = Rack::MockRequest.env_for('/', method: :post)
+        route = @router.recognize('/', method: :post)
+
+        exception = -> { route.call(env) }.must_raise Lotus::Router::NotRoutableEndpointError
+        exception.message.must_equal 'Cannot find routable endpoint for POST "/"'
+      end
+    end
+
+    describe 'from named path' do
+      it 'recognizes proc' do
+        route = @router.recognize(:proc)
+
+        _, _, body = *route.call({})
+
+        body.must_equal      ['OK']
+        route.verb.must_equal 'GET'
+
+        assert route.routable?, "Expected route to be routable"
+      end
+
+      it 'recognizes procs with params' do
+        route = @router.recognize(:params, id: 1)
+
+        route.params.must_equal(id: "1")
+      end
+
+      it 'recognizes action with naming convention (home#index)' do
+        route = @router.recognize(:home)
+
+        _, _, body = *route.call({})
+
+        body.must_equal      ["Hello from Web::Controllers::Home::Index"]
+        route.verb.must_equal 'GET'
+
+        route.action.must_equal('home#index')
+        assert route.routable?, "Expected route to be routable"
+      end
+
+      it 'recognizes action from class' do
+        route = @router.recognize(:dashboard)
+
+        _, _, body = *route.call({})
+
+        body.must_equal      ["Hello from Web::Controllers::Dashboard::Index"]
+        route.verb.must_equal 'GET'
+
+        route.action.must_equal('dashboard#index')
+        assert route.routable?, "Expected route to be routable"
+      end
+
+      it 'recognizes action from rack middleware class' do
+        route = @router.recognize(:rack_class)
+
+        _, _, body = *route.call({})
+
+        body.must_equal      ["RackMiddleware"]
+        route.verb.must_equal 'GET'
+
+        route.action.must_equal('RackMiddleware')
+        assert route.routable?, "Expected route to be routable"
+      end
+
+      it 'recognizes action from rack middleware' do
+        route = @router.recognize(:rack_app)
+
+        _, _, body = *route.call({})
+
+        body.must_equal      ["RackMiddlewareInstanceMethod"]
+        route.verb.must_equal 'GET'
+
+        route.action.must_equal('RackMiddlewareInstanceMethod')
+        assert route.routable?, "Expected route to be routable"
+      end
+
+      it 'returns not routeable result when cannot find named route' do
+        route = @router.recognize(:unknown)
+
+        assert !route.routable?, "Expected route to NOT be routable"
+      end
+
+      it 'returns not routeable result when cannot recognize' do
+        route = @router.recognize(:home, {method: :post}, {})
+
+        assert !route.routable?, "Expected route to NOT be routable"
+      end
+
+      it 'raises error if #call is invoked for not routeable object when cannot recognize' do
+        env   = Rack::MockRequest.env_for('/', method: :post)
+        route = @router.recognize(:home, {method: :post}, {})
+
+        exception = -> { route.call(env) }.must_raise Lotus::Router::NotRoutableEndpointError
+        exception.message.must_equal 'Cannot find routable endpoint for POST "/"'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a proposal for better testing experience.

## Usage

### Path Recognition

```ruby
require 'lotus/router'

router = Lotus::Router.new do
  get '/books/:id', to: 'books#index', as: :book
end

route = router.recognize('/books/23')

route.verb   # => "GET"
route.action # => "books#index"
route.params # => {:id=>"23"}
route.routable? # => true
```

### Rack Env Recognition

```ruby
require 'lotus/router'

router = Lotus::Router.new do
  get '/books/:id', to: 'books#index', as: :book
end

env = Rack::MockRequest.env_for('/books/23')
route = router.recognize(env)

route.verb   # => "GET"
route.action # => "books#index"
route.params # => {:id=>"23"}
route.routable? # => true
```

### Named Route Recognition

```ruby
require 'lotus/router'

router = Lotus::Router.new do
  get '/books/:id', to: 'books#index', as: :book
end

route = router.recognize(:book, id: 23)

route.verb   # => "GET"
route.action # => "books#index"
route.params # => {:id=>"23"}
route.routable? # => true
```

### Failing Path Recognition

```ruby
require 'lotus/router'

router = Lotus::Router.new do
  get '/books/:id', to: 'books#index', as: :book
end

route = router.recognize('/book')

route.verb   # => "GET"
route.routable? # => false
```

### Failing HTTP Verb recognition

```ruby
require 'lotus/router'

router = Lotus::Router.new do
  get '/books/:id', to: 'books#index', as: :book
end

route = router.recognize('/book/23', method: :post)

route.verb   # => "POST"
route.routable? # => false
```

/cc @lotus/core-team 