### PR TITLE
Custom lotus parser json exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,12 @@ curl http://localhost:2300/books/1    \
 # => [200, {}, ["{:published=>\"true\",:id=>\"1\"}"]]
 ```
 
+If the json can't be parsed an exception is raised:
+
+```ruby
+Lotus::Routing::Parsing::BodyParsingError
+``
+
 #### Custom Parsers
 
 ```ruby
@@ -615,7 +621,9 @@ class XmlParser
 
   # Parse body and return a Hash
   def parse(body)
-    # ...
+    # parse xml
+  rescue Lotus::Routing::Parsing::BodyParsingError => e
+    # handle exceptions for XML
   end
 end
 
@@ -634,7 +642,7 @@ curl http://localhost:2300/authors/1 \
   -X PATCH
 
 # => [200, {}, ["{:name=>\"LG\",:id=>\"1\"}"]]
-````
+```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ If the json can't be parsed an exception is raised:
 
 ```ruby
 Lotus::Routing::Parsing::BodyParsingError
-``
+```
 
 #### Custom Parsers
 
@@ -622,8 +622,8 @@ class XmlParser
   # Parse body and return a Hash
   def parse(body)
     # parse xml
-  rescue Lotus::Routing::Parsing::BodyParsingError => e
-    # handle exceptions for XML
+  rescue SomeXmlParsingError => e
+    raise Lotus::Routing::Parsing::BodyParsingError.new(e)
   end
 end
 

--- a/lib/lotus/routing/parsing/json_parser.rb
+++ b/lib/lotus/routing/parsing/json_parser.rb
@@ -3,6 +3,13 @@ require 'json'
 module Lotus
   module Routing
     module Parsing
+      # Json parsing error
+      # This is raised when the json parser fails to parse a json string.
+      #
+      # @since x.x.x
+      class JsonParsingException < ::StandardError
+      end
+
       class JsonParser < Parser
         def mime_types
           ['application/json', 'application/vnd.api+json']
@@ -10,6 +17,8 @@ module Lotus
 
         def parse(body)
           JSON.parse(body)
+        rescue JSON::ParserError => e
+          raise JsonParsingException.new(e.message)
         end
       end
     end

--- a/lib/lotus/routing/parsing/json_parser.rb
+++ b/lib/lotus/routing/parsing/json_parser.rb
@@ -7,7 +7,7 @@ module Lotus
       # This is raised when the json parser fails to parse a json string.
       #
       # @since x.x.x
-      class JsonParsingException < ::StandardError
+      class BodyParsingError < ::StandardError
       end
 
       class JsonParser < Parser
@@ -15,10 +15,20 @@ module Lotus
           ['application/json', 'application/vnd.api+json']
         end
 
+
+        # Parse a json string
+        #
+        # @param body [String] a json string
+        #
+        # @return [Hash] the parsed json
+        #
+        # @raise [BodyParsingError] when the body can't be parsed.
+        #
+        # @since x.x.x
         def parse(body)
           JSON.parse(body)
         rescue JSON::ParserError => e
-          raise JsonParsingException.new(e.message)
+          raise BodyParsingError.new(e.message)
         end
       end
     end

--- a/lib/lotus/routing/parsing/json_parser.rb
+++ b/lib/lotus/routing/parsing/json_parser.rb
@@ -3,18 +3,10 @@ require 'json'
 module Lotus
   module Routing
     module Parsing
-      # Json parsing error
-      # This is raised when the json parser fails to parse a json string.
-      #
-      # @since x.x.x
-      class BodyParsingError < ::StandardError
-      end
-
       class JsonParser < Parser
         def mime_types
           ['application/json', 'application/vnd.api+json']
         end
-
 
         # Parse a json string
         #
@@ -22,7 +14,7 @@ module Lotus
         #
         # @return [Hash] the parsed json
         #
-        # @raise [BodyParsingError] when the body can't be parsed.
+        # @raise [Lotus::Routing::Parsing::BodyParsingError] when the body can't be parsed.
         #
         # @since x.x.x
         def parse(body)

--- a/lib/lotus/routing/parsing/parser.rb
+++ b/lib/lotus/routing/parsing/parser.rb
@@ -4,6 +4,13 @@ require 'lotus/utils/string'
 module Lotus
   module Routing
     module Parsing
+      # Body parsing error
+      # This is raised when parser fails to parse the body
+      #
+      # @since x.x.x
+      class BodyParsingError < ::StandardError
+      end
+
       class UnknownParserError < ::StandardError
         def initialize(parser)
           super("Unknown Parser: `#{ parser }'")

--- a/test/routing/parsers_test.rb
+++ b/test/routing/parsers_test.rb
@@ -48,6 +48,13 @@ describe Lotus::Routing::Parsers do
           result = @parsers.call(env)
           result['router.params'].must_equal({"attribute" => "ok"})
         end
+
+        describe 'with malformed json' do
+          let(:body) {  %({"lotus":"ok" "attribute":"ok"}) }
+          it 'raises an exception' do
+            -> { result = @parsers.call(env) }.must_raise(Lotus::Routing::Parsing::JsonParsingException)
+          end
+        end
       end
 
       describe 'and a JSON API request' do
@@ -57,6 +64,13 @@ describe Lotus::Routing::Parsers do
         it "parses params from body" do
           result = @parsers.call(env)
           result['router.params'].must_equal({"attribute" => "ok"})
+        end
+
+        describe 'with malformed json' do
+          let(:body) {  %({"lotus":"ok" "attribute":"ok"}) }
+          it 'raises an exception' do
+            -> { result = @parsers.call(env) }.must_raise(Lotus::Routing::Parsing::JsonParsingException)
+          end
         end
       end
 

--- a/test/routing/parsers_test.rb
+++ b/test/routing/parsers_test.rb
@@ -52,7 +52,7 @@ describe Lotus::Routing::Parsers do
         describe 'with malformed json' do
           let(:body) {  %({"lotus":"ok" "attribute":"ok"}) }
           it 'raises an exception' do
-            -> { result = @parsers.call(env) }.must_raise(Lotus::Routing::Parsing::JsonParsingException)
+            -> { result = @parsers.call(env) }.must_raise(Lotus::Routing::Parsing::BodyParsingError)
           end
         end
       end
@@ -69,7 +69,7 @@ describe Lotus::Routing::Parsers do
         describe 'with malformed json' do
           let(:body) {  %({"lotus":"ok" "attribute":"ok"}) }
           it 'raises an exception' do
-            -> { result = @parsers.call(env) }.must_raise(Lotus::Routing::Parsing::JsonParsingException)
+            -> { result = @parsers.call(env) }.must_raise(Lotus::Routing::Parsing::BodyParsingError)
           end
         end
       end


### PR DESCRIPTION
Closes #46 

Raise a custom lotus exception when the json parser fails to parse a malformed json.

If you have to implement a middleware to rescue json parser errors raised from lotus json parser, you can rescue `Lotus::Routing::Parsing::JsonParsingException` exception instead `JSON::ParseError` exception.

cc @lotus/core-team 