### PR TITLE
Add option for display header text for routes inspector

### DIFF
--- a/lib/lotus/routing/routes_inspector.rb
+++ b/lib/lotus/routing/routes_inspector.rb
@@ -18,6 +18,29 @@ module Lotus
       # @api private
       HTTP_METHODS_SEPARATOR = ', '.freeze
 
+      # Default inspector header hash values
+      #
+      # @since 0.5.0
+      # @api private
+      INSPECTOR_HEADER_HASH =  Hash[
+        name:     'Name',
+        methods:  'Method',
+        path:     'Path',
+        endpoint: 'Action'
+      ].freeze
+
+      # Default inspector header name values
+      #
+      # @since 0.5.0
+      # @api private
+      INSPECTOR_HEADER_NAME = 'Name'.freeze
+
+      # Empty line string
+      #
+      # @since 0.5.0
+      # @api private
+      EMPTY_LINE = "\n".freeze
+
       # Instantiate a new inspector
       #
       # @return [Lotus::Routing::RoutesInspector] the new instance
@@ -50,8 +73,10 @@ module Lotus
       #   end
       #
       #   puts router.inspector.to_s
-      #     # =>        GET, HEAD  /                        Home::Index
-      #          login  GET, HEAD  /login                   Sessions::New
+      #     # =>   Name Method     Path                     Action
+      #
+      #                 GET, HEAD  /                        Home::Index
+      #           login GET, HEAD  /login                   Sessions::New
       #                 POST       /login                   Sessions::Create
       #          logout GET, HEAD  /logout                  Sessions::Destroy
       #
@@ -68,7 +93,9 @@ module Lotus
       #   formatter = "| %{methods} | %{name} | %{path} | %{endpoint} |\n"
       #
       #   puts router.inspector.to_s(formatter)
-      #     # => | GET, HEAD |        | /       | Home::Index       |
+      #     # => | Method    | Name   | Path    | Action            |
+      #
+      #          | GET, HEAD |        | /       | Home::Index       |
       #          | GET, HEAD | login  | /login  | Sessions::New     |
       #          | POST      |        | /login  | Sessions::Create  |
       #          | GET, HEAD | logout | /logout | Sessions::Destroy |
@@ -100,10 +127,12 @@ module Lotus
       #   formatter = "| %{methods} | %{name} | %{path} | %{endpoint} |\n"
       #
       #   puts router.inspector.to_s(formatter)
-      #     # => | GET, HEAD |  | /fakeroute                 | Fake::Index     |
-      #          | GET, HEAD |  | /admin/home                | Home::Index     |
-      #          | GET, HEAD |  | /api/posts                 | Posts::Index    |
-      #          | GET, HEAD |  | /api/second_mount/comments | Comments::Index |
+      #     # => | Method    | Name | Path                       | Action          |
+      #
+      #          | GET, HEAD |      | /fakeroute                 | Fake::Index     |
+      #          | GET, HEAD |      | /admin/home                | Home::Index     |
+      #          | GET, HEAD |      | /api/posts                 | Posts::Index    |
+      #          | GET, HEAD |      | /api/second_mount/comments | Comments::Index |
       def to_s(formatter = FORMATTER, base_path = nil)
         base_path = Utils::PathPrefix.new(base_path)
         result    = ''
@@ -117,6 +146,10 @@ module Lotus
           else
             inspect_route(formatter, route, base_path)
           end
+        end
+
+        unless result.include?(INSPECTOR_HEADER_NAME)
+          result.insert(0, formatter % INSPECTOR_HEADER_HASH + EMPTY_LINE)
         end
 
         result

--- a/test/routing/routes_inspector_test.rb
+++ b/test/routing/routes_inspector_test.rb
@@ -252,5 +252,20 @@ describe Lotus::Routing::RoutesInspector do
         end
       end
     end
+
+    describe 'with header option' do
+      before do
+        @router = Lotus::Router.new do
+          get '/controller/action', to: 'welcome#index'
+        end
+      end
+
+      it 'returns header text' do
+        expectation = %(Name Method     Path                           Action)
+
+        actual = @router.inspector.to_s
+        actual.must_include(expectation)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Why this is needful
This option will provide better formatting for `lotus routes` command, for example:
```
~/work/lotus_server » lotus routes
                Name Method   Path                      Action
                     POST     /api/action               Api::Controllers::Files::Action
```

/cc @jodosha